### PR TITLE
Allow user to see themselves in the block

### DIFF
--- a/block_meet_the_students.php
+++ b/block_meet_the_students.php
@@ -120,6 +120,7 @@ class block_meet_the_students extends block_base {
         $config = get_config('block_meet_the_students'); // Defaults.
         $onlywithrole = isset($this->config->onlywithrole) ? $this->config->onlywithrole : $config->onlywithrole;
         $onlywithpic = isset($this->config->onlywithpic) ? $this->config->onlywithpic : $config->onlywithpic;
+        $displaycurrentuser = isset($this->config->displaycurrentuser) ? $this->config->displaycurrentuser : $config->displaycurrentuser;
         $numcolumns = (isset($this->config->numcolumns) ? $this->config->numcolumns : $config->numcolumns) + 1;
         $numrows = (isset($this->config->numrows) ? $this->config->numrows : $config->numrows) + 1;
         $maxusers = $numcolumns * $numrows;
@@ -133,8 +134,10 @@ class block_meet_the_students extends block_base {
             $users = get_enrolled_users($context);
         }
 
-        // Remove own profile.
-        unset($users[$USER->id]);
+        if (!$displaycurrentuser) {
+            // Remove own profile.
+            unset($users[$USER->id]);
+        }
 
         // Only users with profile pictures.
         if ($onlywithpic) {

--- a/edit_form.php
+++ b/edit_form.php
@@ -61,6 +61,10 @@ class block_meet_the_students_edit_form extends block_edit_form {
         $mform->addElement('advcheckbox', 'config_onlywithpic', get_string('onlywithpic', 'block_meet_the_students'));
         $mform->setDefault('config_onlywithpic', $config->onlywithpic);
 
+        // Display Current User
+        $mform->addElement('advcheckbox', 'config_displaycurrentuser', get_string('displaycurrentuser', 'block_meet_the_students'));
+        $mform->setDefault('config_displaycurrentuser', $config->displaycurrentuser);
+
         // Only with specific role.
         $roles = get_assignable_roles(context_course::instance(1));
         $roles[0] = 'All';

--- a/lang/en/block_meet_the_students.php
+++ b/lang/en/block_meet_the_students.php
@@ -35,6 +35,9 @@ $string['numrowsdesc'] = 'Default number of rows of profiles to display for new 
 $string['onlywithpic'] = 'Only Users with Picture';
 $string['onlywithpicdesc'] = 'By default only display users with profile pictures for new blocks.';
 
+$string['displaycurrentuser'] = 'User Can See Themselves';
+$string['displaycurrentuserdesc'] = 'By default do not display themselves to the user';
+
 $string['onlywithrole'] = 'Only Users with a particular role';
 $string['onlywithroledesc'] = 'By default display all users.';
 

--- a/settings.php
+++ b/settings.php
@@ -48,6 +48,13 @@ if ($ADMIN->fulltree) {
     $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
     $settings->add($setting);
 
+    $name = 'block_meet_the_students/displaycurrentuser';
+    $title = get_string('displaycurrentuser', 'block_meet_the_students');
+    $description = get_string('displaycurrentuserdesc', 'block_meet_the_students');
+    $default = 0;
+    $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
+    $settings->add($setting);
+
     $name = 'block_meet_the_students/onlywithrole';
     $title = get_string('onlywithrole', 'block_meet_the_students');
     $description = get_string('onlywithroledesc', 'block_meet_the_students');


### PR DESCRIPTION
Added a setting that allows admins to turn on and off the ability for users to see themselves in the meet the students block.

This is for when the block is used to display Top Achievers, users will want to see themselves.