### PR TITLE
Moodle 3.3+ image_url() fix: Handles pix_url() deprecated as of Moodle 3.3.

### DIFF
--- a/block_meet_the_students.php
+++ b/block_meet_the_students.php
@@ -101,7 +101,12 @@ class block_meet_the_students extends block_base {
         if ($canviewuserdetails) {
             $meetallstudentsurl = new moodle_url('/user/index.php', array('contextid' => $context->id));
             $text = get_string('meetall', 'block_meet_the_students');
-            $meetallstudentsanchor = html_writer::empty_tag('img', array('src' => $OUTPUT->pix_url('i/users'), 'alt' => $text));
+            if ($CFG->branch >= 33) { // Moodle 3.3+.
+                $pixurl = $OUTPUT->image_url('i/users');
+            } else {
+                $pixurl = $OUTPUT->pix_url('i/users');
+            }
+            $meetallstudentsanchor = html_writer::empty_tag('img', array('src' => $pixurl, 'alt' => $text));
             $meetallstudentsanchor .= ' ' . $text;
             $this->content->footer = html_writer::link($meetallstudentsurl, $meetallstudentsanchor);
         }


### PR DESCRIPTION
This makes the moodle-block_meet_the_students plugin compatible with Moodle 3.3 and 3.4. It still uses pix_url(), deprecated as of Moodle 3.3, for backwards compatibility with older versions of Moodle but uses the new image_url() when running on Moodle 3.3+.

For more information, see #11.

Let me know if you have any questions or concerns with this pull request.

Michael Milette